### PR TITLE
add option --parallel-salt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,14 @@ respectively) are also natively supported.
 
 Additionally, if you want to further randomize the distribution of tests, so
 that the same test cases don't always run together on the same node, you may
-use the ``--parallel-salt`` option to specify a salt value (e.g. a build number, the
-day of the month). Alternatively you can set environment variable
-``NOSE_PARALLEL_SALT``. And, as an added convenience, you can change this environment variable to something
-your build environment already configures for each build with the option ``--parallel-salt-env``. E.g. on CircleCI you could do:
+use the ``--parallel-salt`` option to specify a salt value (e.g. a build
+number, the day of the month). Obviously the salt must be the same on each node
+during a parallel build otherwise some test cases might be missed.
+
+Alternatively you can set environment variable ``NOSE_PARALLEL_SALT``. And, as
+an added convenience, you can change this environment variable to something
+your build environment already configures for each build with the option
+``--parallel-salt-env``. E.g. on CircleCI you could do:
 
 .. code:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,17 @@ If you don't set those variables, ``nose-parallel`` will do the right thing and 
 The CircleCI versions of the environment variables (``CIRCLE_NODE_TOTAL`` and ``CIRCLE_NODE_INDEX``, 
 respectively) are also natively supported.
 
+Additionally, if you want to further randomize the distribution of tests, so
+that the same test cases don't always run together on the same node, you may
+use the ``--parallel-salt`` option to specify a salt value (e.g. a build number, the
+day of the month). Alternatively you can set environment variable
+``NOSE_PARALLEL_SALT``. And, as an added convenience, you can change this environment variable to something
+your build environment already configures for each build with the option ``--parallel-salt-env``. E.g. on CircleCI you could do:
+
+.. code:: bash
+
+    nosetests --with-parallel --with-parallel-salt-env CIRCLE_BUILD_NUM
+
 
 License
 -------


### PR DESCRIPTION
This PR adds support for randomizing the distribution of test cases to each node. Currently unless you rename your test methods or change the number of nodes, the same tests will run on the same nodes every time. If this isn't desirable a user can add a salt value to the name's hash, providing it via a command line argument `--parallel-salt` or via an environment variable. Obviously the salt must be the same for a particular build across the nodes if we want to make sure all tests are run.