### PR TITLE
Supressed AttributeError would prevent the plugin from working properly under python3

### DIFF
--- a/noseparallel/plugin.py
+++ b/noseparallel/plugin.py
@@ -18,8 +18,7 @@ class ParallelPlugin(Plugin):
 
     def wantMethod(self, method):
         try:
-            cls = method.im_class
-            return self._pick_by_name(cls.__name__)
+            return self._pick_by_name(method.__name__)
         except AttributeError:
             return None
         return None
@@ -32,8 +31,8 @@ class ParallelPlugin(Plugin):
         return None
 
     def _pick_by_name(self, name):
-        m = hashlib.md5(self.salt)
-        m.update(name)
+        m = hashlib.md5(self.salt.encode('utf-8'))
+        m.update(name.encode('utf-8'))
         class_numeric_id = int(m.hexdigest(), 16)
         if class_numeric_id % self.total_nodes == self.node_index:
             return None

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -1,0 +1,37 @@
+import unittest
+from noseparallel import ParallelPlugin
+
+
+class PluginTest(unittest.TestCase):
+
+    def f(self):
+        pass
+
+    def test_want_method_should_accept_on_either_nodes_but_not_both(self):
+        plugin = ParallelPlugin()
+        plugin.salt = 'test'
+        plugin.total_nodes = 2
+
+        plugin.node_index = 0
+        rv0 = plugin.wantMethod(self.f)
+
+        plugin.node_index = 1
+        rv1 = plugin.wantMethod(self.f)
+
+        self.assertEqual({None, False}, {rv0, rv1})
+
+    def test_want_function_should_accept_on_either_nodes_but_not_both(self):
+        def f():
+            pass
+
+        plugin = ParallelPlugin()
+        plugin.salt = 'test'
+        plugin.total_nodes = 2
+
+        plugin.node_index = 0
+        rv0 = plugin.wantFunction(f)
+
+        plugin.node_index = 1
+        rv1 = plugin.wantFunction(f)
+
+        self.assertEqual({None, False}, {rv0, rv1})


### PR DESCRIPTION
Two issues prevented the plugin from working under python3:
- im_class no longer exists, replaced with simply method.**name**
- hashlib now requires bytes to be provided rather than a string

Both issues went undetected because of the caught AttributeError, causing no balancing between nodes at all.

I also added some basic tests and validated the implementation under python3.5 and python2.7.
